### PR TITLE
Adding support for refreshAuthToken in hubcontroller + associated uni…

### DIFF
--- a/node/hubController.js
+++ b/node/hubController.js
@@ -96,6 +96,27 @@ class HubController {
     }
 
     /**
+     * Given a specific hub info, onboardingInfo, and existing authInfo blob,
+     *  does the OAuthToken refresh, and returns the refreshed
+     * auth info object back.
+     */
+    refreshAuthToken(hubId, onboardingInfo, existingAuthInfo){
+        console.log("----------------- refreshAuthToken");
+
+        return this._getHubInfo(hubId).then((hubInfo) => {
+
+            // create hub translator for given hubId
+            return this._createTranslator(hubInfo.translator, existingAuthInfo).then((hubInstance) => {
+                
+                // hub refreshAuthToken
+                return this._invokeMethod(hubInstance, "", "refreshAuthToken", [onboardingInfo]);
+            });
+        }).catch((err) => {
+            this._logError(err, "refreshAuthToken");
+        });
+    }
+
+    /**
      * given the specific hub id, returns all the platforms which are connected to it
      */
     platforms(hubId, authInfo) {
@@ -179,7 +200,7 @@ class HubController {
     }
 
     _invokeMethod(translator, deviceInfo, methodName, params) {
-        console.log("----------------- _invokeMethod " + methodName);
+        console.log("----------------- _invokeMethod " + methodName + " with params "+ JSON.stringify(params));
 
         if (typeof translator === "object") {
             return this.OpenT2T.invokeMethodAsync(translator, "", methodName, params);

--- a/node/tests/hubController.js
+++ b/node/tests/hubController.js
@@ -20,10 +20,8 @@ test.serial("Valid Hub Controller", t => {
 ///
 
 test.serial("RefreshAuthToken returns a valid non-error response", async t => {
-    console.log("DEBUGGING - AuthInfo");
-    console.log(authInfo);
     var refreshedAuthInfo = await hubController.refreshAuthToken(config.hubId, config.onboardingInfo, authInfo);
-    console.log("*******************");
+    console.log("********New Auth Info***********");
     console.log(JSON.stringify(refreshedAuthInfo));
     console.log("*******************");
     t.truthy(refreshedAuthInfo);

--- a/node/tests/hubController.js
+++ b/node/tests/hubController.js
@@ -19,6 +19,17 @@ test.serial("Valid Hub Controller", t => {
 /// Run a series of tests to validate the translator
 ///
 
+test.serial("RefreshAuthToken returns a valid non-error response", async t => {
+    console.log("DEBUGGING - AuthInfo");
+    console.log(authInfo);
+    var refreshedAuthInfo = await hubController.refreshAuthToken(config.hubId, config.onboardingInfo, authInfo);
+    console.log("*******************");
+    console.log(JSON.stringify(refreshedAuthInfo));
+    console.log("*******************");
+    t.truthy(refreshedAuthInfo);
+    t.not(refreshedAuthInfo.accessToken, authInfo.accessToken, "refreshAuthToken failed to update auth token"); 
+});
+
 test.serial('SupportedHubs', async t => {
     var supportedHubs = await hubController.supportedHubs();
     console.log("*******************");
@@ -31,6 +42,7 @@ test.serial('SupportedHubs', async t => {
 
 test.serial('GetPlatforms', async t => {
     var platforms = await hubController.platforms(config.hubId, authInfo);
+    console.log(platforms);
     t.truthy(platforms);
     t.is(platforms.platforms.length > 0, true);
 });


### PR DESCRIPTION
refreshAuthToken API + unit test;
NOTE: Existing translators/hubs are broken at the moment because of Issue# https://github.com/openT2T/translators/issues/129 

I tested this with the new test and the workaround to move the function providerSchemaToPlatformSchema back into the Translator class. But the last getPlatforms test is *still* failing.
**************************** TEST OUTPUT *********** (Secrets obfuscated)

C:\opent2t\sj\cloud\node\tests>ava hubController.js
----------------- onboard
----------------- _getHubInfo
----------------- supportedHubs
------------------------------
i: 0
----------------------------- Package Info
{ moduleName: 'opent2t.p.hub/com.wink.hub/js/thingTranslator',
  onboarding: 'opent2t-onboarding-org-opent2t-onboarding-winkhub/org.opent2t.onboarding.winkhub/js/thingOnboarding',
  onboardingFlow:
   [ { flow: [Object], name: 'getUserInput' },
     { flow: [Object], name: 'getDeveloperInput' } ],
  onboardingProperties: {},
  schemas: [ 'opent2t-translator-com-wink-hub/opent2t.p.hub/opent2t.p.hub' ] }
-----------------------------
Onboarding Wink Hub
----------------- refreshAuthToken
----------------- _getHubInfo
----------------- _createTranslator opent2t-translator-com-wink-hub
----------------- _invokeMethod refreshAuthToken with params [[{"username":"***","password":"****"},{"client_id":"*****","client_secret":"****"}]]
*******************
{"accessToken":"****","refreshToken":"***","tokenType":"bearer","scopes":"full_access"}
*******************
*******************
[
  {
    "id": "winkHub",
    "name": "Wink",
    "translator": "opent2t-translator-com-wink-hub",
    "onboarding": "opent2t-onboarding-org-opent2t-onboarding-winkhub/org.opent2t.onboarding.winkhub/js/thingOnboarding",
    "onboardingFlow": [
      {
        "flow": [
          {
            "descriptions": {
              "en": "Type in your Wink username",
              "fr": "Entrez for nom pour Wink"
            },
            "name": "username",
            "type": "input"
          },
          {
            "descriptions": {
              "en": "Type in your Wink password",
              "fr": "Entrez for password pour Wink"
            },
            "name": "password",
            "type": "password"
          }
        ],
        "name": "getUserInput"
      },
      {
        "flow": [
          {
            "descriptions": {
              "en": "Ask for Client id",
              "fr": "Demandez Client ID"
            },
            "name": "client_id"
          },
          {
            "descriptions": {
              "en": "Ask for Client Secret",
              "fr": "Demandez Client Secret"
            },
            "name": "client_secret"
          }
        ],
        "name": "getDeveloperInput"
      }
    ]
  }
]
*******************
----------------- platforms
----------------- _getHubInfo
----------------- _createTranslator opent2t-translator-com-wink-hub
----------------- _invokeMethod getPlatforms with params [true]
Wink Lightbulb initializing...
Wink Lightbulb initializing...Done
Wink Binary Switch initializing...
Wink Binary Switch initializing...Done
undefined
----------------- getPlatform
----------------- _getHubInfo
----------------- _createTranslator opent2t-translator-com-wink-hub
----------------- _invokeMethod get with params [true]
----------------- _createTranslator opent2t-translator-com-wink-lightbulb
Wink Lightbulb initializing...
Wink Lightbulb initializing...Done

   4 passed
   1 failed


   1. GetPlatforms

  t.truthy(platforms)
        ?
        ?
        SyntaxError: Unexpected token (1:6)

  If you are using `babel-plugin-espower` and want to use experimental syntax in your assert(), you should set `embedAst` option to true.
  see: https://github.com/power-assert-js/babel-plugin-espower#optionsembedast



      _callee4$ (hubController.js:46:7)
    tryCatch (node_modules/regenerator-runtime/runtime.js:63:40)
    GeneratorFunctionPrototype.invoke [as _invoke] (node_modules/regenerator-runtime/runtime.js:337:22)
    GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (node_modules/regenerator-runtime/runtime.js:96:21)



