### PR TITLE
Updating HubController to no longer swallow errors but reject promises with custom OpenT2TError

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@ A sample server that can be can be used to interact with similar devices using a
 > **Important:** This is just a code sample and NOT intended for any sort of real use since it does not implement any real auth or persistent storage.
 
 The API for this sample is documented at: http://docs.opent2t.apiary.io
+> **Note:** The Apiary hasnt been updated yet for error cases but soon will be. Meanwhile the section below talks about the general behavior.
+
+## General Error handling notes
+All APIs defined here return a custom Error object of type OpenT2TError defined in the opent2t common client library (https://github.com/openT2T/opent2t).
+
+1. Any errors that are bubbled out from the library are wrapped in a custom OpenT2TError (extends built-in Error interface). All APIs are promise-based, and in case of errors, the promise is rejected with given error.
+
+2. Users of this library will be able to handle the error in their code and view the status code, message, original 'inner' error for diagnostics.
+
+3. The error code is typically matched to a corresponding HTTPStatusCode if not already originally one in the inner error. Eg 400's for bad request input or validation failures, 500 for default/unexpected/technical errors etc
+
+4. Errors from providers eg WINK etc are returned as-is and their original error codes and messages retained.
+
 
 ## Code of Conduct
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,37 @@ All APIs defined here return a custom Error object of type OpenT2TError defined 
 
 ## Running tests
 
-1. To run the tests, you need first install the test framework 'ava'.
-``
+1. To run the tests, you need first install the node dependencies under the root cloud\node folder.
+> `npm install`
+
+2. Next, ensure install the rest of the dependencies in particular, ava (the testing framework), opent2t, and the specific hub translator you are working with, are explicitly installed. Only WINK is supported at this time in the tests. The tests also require actual wink hub setup (username/pwd etc and work against the production wink service)
+> `npm install ava`
+> `npm install opent2t`
+> `npm install opent2t-translator-com-wink-hub`
+
+3. Next,(temporary step only until we fix this) copy the node_modules folder into the tests directory
+
+4. cd to the tests folder
+
+5. create a new hubController-testConfig-auth.json file. This has to be named this exact name. Populate with the onboardinginfo below and replace the contents with your username + id:
+
+{
+ "onboardingInfo" : [
+        {
+            "username": "",
+            "password": ""
+        },
+        {
+            "client_id": "",
+            "client_secret": ""
+        }
+    ]
+}
+
+6. Next if you know already your device ids + control ids (for wink) populate them in the hubController-testConfig.json file or run the test once, look at the output with your device information and populate with your deviceId, control id in the test config.
+
+7. Run the test : ava hubcontroller.js
+
+
 ## Code of Conduct
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A sample server that can be can be used to interact with similar devices using a
 > **Important:** This is just a code sample and NOT intended for any sort of real use since it does not implement any real auth or persistent storage.
 
 The API for this sample is documented at: http://docs.opent2t.apiary.io
-> **Note:** The Apiary hasnt been updated yet for error cases but soon will be. Meanwhile the section below talks about the general behavior.
+> **Note:** The Apiary hasn't been updated yet for error cases but soon will be. Meanwhile the section below talks about the general behavior.
 
 ## General Error handling notes
 All APIs defined here return a custom Error object of type OpenT2TError defined in the opent2t common client library (https://github.com/openT2T/opent2t).
@@ -15,8 +15,11 @@ All APIs defined here return a custom Error object of type OpenT2TError defined 
 
 3. The error code is typically matched to a corresponding HTTPStatusCode if not already originally one in the inner error. Eg 400's for bad request input or validation failures, 500 for default/unexpected/technical errors etc
 
-4. Errors from providers eg WINK etc are returned as-is and their original error codes and messages retained.
+4. Errors from providers eg WINK etc are returned as-is and their original error codes and messages retained. The original error is bubbled up in the nested err property of the message.
 
+## Running tests
 
+1. To run the tests, you need first install the test framework 'ava'.
+``
 ## Code of Conduct
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/node/hubController.js
+++ b/node/hubController.js
@@ -280,7 +280,7 @@ class HubController {
 
             if (hubInfo == undefined) {
                 console.log("invalid hub id");
-                throw new Error("Invalid hub id");
+                throw new OpenT2TErrorClass(400, "Invalid hub id");
             }
 
             return hubInfo;
@@ -321,13 +321,15 @@ class HubController {
     }
 
     _handleError(err, message) {
-        let customMessage = "OpenT2T call failed in: " + message + "; Original message: ";
+        let customMessage = "OpenT2T call failed in: " + message + "; Original message: "; 
         
-        if (err.response.statusMessage) {
-            // This was a result of a failed HTTP Request
+        // This was a result of a failed HTTP Request promise
+        // Can also check err.Name
+        if ('response' in err && 'statusMessage' in err.response) {
             customMessage = customMessage + err.response.statusMessage;
-        }
+        }   
         else {
+            // Likely an simple Error-derived class 
             customMessage = customMessage + err.message;
         }
 

--- a/node/hubController.js
+++ b/node/hubController.js
@@ -4,7 +4,8 @@
 
 var q = require('q');
 var hubsConfig = require("./hubsConfig");
-var OpenT2TErrorClass = require('opent2t').OpenT2TError;
+var OpenT2TError = require('opent2t').OpenT2TError;
+var OpenT2TConstants = require('opent2t').OpenT2TConstants;
 
 class HubController {
 
@@ -269,7 +270,7 @@ class HubController {
         return this.supportedHubs().then((hubs) => {
             // find the hub referenced by hubId
             var hubInfo = undefined;
-            for (var i = 0; hubInfo == undefined && i < hubs.length; i++) {
+            for (var i = 0; hubInfo === undefined && i < hubs.length; i++) {
                 var hub = hubs[i];
 
                 // intentional ==
@@ -278,9 +279,9 @@ class HubController {
                 }
             }
 
-            if (hubInfo == undefined) {
+            if (!hubInfo) {
                 console.log("invalid hub id");
-                throw new OpenT2TErrorClass(400, "Invalid hub id");
+                throw new OpenT2TError(404, OpenT2TConstants.InvalidHubId);
             }
 
             return hubInfo;
@@ -333,7 +334,7 @@ class HubController {
             customMessage = customMessage + err.message;
         }
 
-        let customError = new OpenT2TErrorClass(err.statusCode, customMessage, err);
+        let customError = new OpenT2TError(err.statusCode, customMessage, err);
         console.log(" custom error message:           " + customError.message);
         console.log(" custom error name:           " + customError.name);
         console.log(" custom error statusCode:           " + customError.statusCode);

--- a/node/hubController.js
+++ b/node/hubController.js
@@ -321,27 +321,16 @@ class HubController {
     }
 
     _handleError(err, message) {
-        console.log("------------ API failed: -" + message);
+        let customMessage = "OpenT2T call failed in: " + message + "; Original message: ";
         
-        // If already an OpenT2TError type reject right-away; Nothing to transform
-        if (err instanceof OpenT2TErrorClass){
-            console.log(" OpenT2t error message:           " + err.message);
-            console.log(" OpenT2t error name:           " + err.name);
-            console.log(" OpenT2t error statusCode:           " + err.statusCode);
-            console.log(" OpenT2t error innerError message:           " +  err.innerError.message);
-            console.log(" OpenT2t error innerError stack:           " +  err.innerError.stack);
-
-            return q.reject(err);
-        }
-
-        var customMessage = "OpenT2T call failed in: " + message + "; Original message: ";
-        if (err.response.statusMessage){
+        if (err.response.statusMessage) {
+            // This was a result of a failed HTTP Request
             customMessage = customMessage + err.response.statusMessage;
         }
-        else{
+        else {
             customMessage = customMessage + err.message;
         }
-    
+
         let customError = new OpenT2TErrorClass(err.statusCode, customMessage, err);
         console.log(" custom error message:           " + customError.message);
         console.log(" custom error name:           " + customError.name);

--- a/node/tests/hubController-testConfig-Invalidauth.json
+++ b/node/tests/hubController-testConfig-Invalidauth.json
@@ -1,0 +1,8 @@
+{
+ "onboardingInfo" : [
+        { 
+            "username": "blah",
+            "password": "somepwd"
+        }
+    ]
+}

--- a/node/tests/hubController-testConfig.json
+++ b/node/tests/hubController-testConfig.json
@@ -4,23 +4,23 @@
         "opent2tBlob" : {
             "schema":"opent2t.p.light",
             "translator":"opent2t-translator-com-wink-lightbulb",
-            "controlId":"2120684"
+            "controlId":"2167953"
         }
     }, 
     "setResource": { 
         "opent2tBlob" : {
             "schema":"opent2t.p.light",
             "translator":"opent2t-translator-com-wink-lightbulb",
-            "controlId":"2120684"
+            "controlId":"2167953"
         },
-        "deviceId": "",
+        "deviceId": "F8CFB903-58BB-4753-97E0-72BD7DBC7933",
         "resource": "power",
         "resourceBlob": {"value":true}
     },
     "subscriptionInfo": {
-        "callbackUrl": "http://drsubscriptiontest.azurewebsites.net/subs",
-        "key": "imalwaysangry"
-    },
+            "callbackUrl": "http://drsubscriptiontest.azurewebsites.net/subs",
+            "key": "imalwaysangry"
+        },
     "subscription": {
         "topic" : "http://someserver/light_bulbs/2120684",
         "challenge" : "challengestring",

--- a/node/tests/hubController.js
+++ b/node/tests/hubController.js
@@ -1,6 +1,7 @@
 const sleep = require('es6-sleep').promise;
 var test = require('ava');
 var config = require('./hubController-testConfig');
+var OpenT2TErrorClass = require('opent2t').OpenT2TError;
 
 // Separate out authorization info to avoid accidentally commiting passwords and keys
 // File must contain onboarding info for the hub:
@@ -71,14 +72,14 @@ test.serial('getPlatform', async t => {
 
 test.serial('subscribePlatform', async t => {
     // Subscribe the the platform specified in the test config
-    var subscription = await hubController.subscribePlatform(config.hubId, authInfo, config.getPlatform.opent2tBlob, config.subscription.subscriptionInfo);
+    var subscription = await hubController.subscribePlatform(config.hubId, authInfo, config.getPlatform.opent2tBlob, config.subscriptionInfo);
     console.log(JSON.stringify(subscription, null, 2));
     t.truthy(subscription);
     t.truthy(subscription.expiration);
 });
 
 test.serial('unsubscribePlatform', async t => {
-    var subscription = await hubController.unsubscribePlatform(config.hubId, authInfo, config.getPlatform.opent2tBlob, config.subscription.subscriptionInfo);
+    var subscription = await hubController.unsubscribePlatform(config.hubId, authInfo, config.getPlatform.opent2tBlob, config.subscriptionInfo); 
     console.log(JSON.stringify(subscription, null, 2));
     t.truthy(subscription);
     t.is(subscription.expiration, 0);
@@ -86,13 +87,15 @@ test.serial('unsubscribePlatform', async t => {
 
 test.serial('subscribeVerify', async t => {
     // Verify PubSubHubbub (Wink) style subscription verification.
-    config.subscriptionInfo.verificationRequest = {};
-    config.subscriptionInfo.verificationRequest.url = "http://contoso.com:8000?hub.topic=" + config.subscription.topic +
+    var verificationRequest = {}; 
+ 
+    verificationRequest.url = "http://contoso.com:8000?hub.topic=" + config.subscription.topic + 
         "&hub.challenge=" + config.subscription.challenge + 
         "&hub.lease_seconds=" + config.subscription.expiration +
         "&hub.mode=subscribe";
     
-    var subscription = await hubController.subscribeVerify(config.hubId, authInfo, config.subscription.subscriptionInfo);
+    var subscription = await hubController.subscribeVerify(config.hubId, authInfo, verificationRequest); 
+
     console.log(JSON.stringify(subscription, null, 2));
     t.truthy(subscription);
     t.is(subscription.response, config.subscription.challenge);
@@ -104,10 +107,14 @@ test.serial('translatePlatforms', async t => {
     verificationInfo.key = config.subscriptionInfo.key;
 
     // Calculate an HMAC for the message that will be validated successfully
-    var hmac = require('crypto').createHmac('sha1', config.subscription.key);
-    hmac.update(config.subscription.sampleFeed);
-    verificationInfo.hmac = hmac.digest(config.subscription.sampleFeed);
-    
+    var hmac = require('crypto').createHmac('sha1', config.subscriptionInfo.key); 
+
+    hmac.update(config.subscription.sampleFeed.toString()); 
+    verificationInfo.hmac = hmac.digest("hex"); 
+    verificationInfo.header = { 
+       "X-Hub-Signature": verificationInfo.hmac 
+   }; 
+
     var translatedFeed = await hubController.translatePlatforms(config.hubId, authInfo, config.subscription.sampleFeed, verificationInfo);
     console.log(JSON.stringify(translatedFeed, null, 2));
     t.truthy(translatedFeed);
@@ -122,7 +129,12 @@ test.serial('translatePlatformsInvalidHmac', async t => {
 
     var verificationInfo = {};
     verificationInfo.key = config.subscriptionInfo.key;
-    verifcationInfo.hmac = "this_wont_match_the_hash";
-
-    t.throws(hubController.translatePlatforms(config.hubId, authInfo, config.subscription.sampleFeed, verificationInfo));
+    verificationInfo.header = { 
+    "X-Hub-Signature": "this_wont_match_the_hash" 
+    }; 
+ 
+   // Verify that no platforms are translated as the signatures did not match. 
+   const error = await t.throws(hubController.translatePlatforms(config.hubId, authInfo, config.subscription.sampleFeed, verificationInfo)); 
+   t.is(error.name, "OpenT2TError");
+   t.is(error.statusCode, 400);
 });

--- a/node/tests/hubController.js
+++ b/node/tests/hubController.js
@@ -1,7 +1,7 @@
 const sleep = require('es6-sleep').promise;
 var test = require('ava');
 var config = require('./hubController-testConfig');
-var OpenT2TErrorClass = require('opent2t').OpenT2TError;
+var OpenT2TConstants = require('opent2t').OpenT2TConstants;
 
 // Separate out authorization info to avoid accidentally commiting passwords and keys
 // File must contain onboarding info for the hub:
@@ -137,28 +137,28 @@ test.serial('translatePlatformsInvalidHmac', async t => {
    // Verify that no platforms are translated as the signatures did not match. 
    const error = await t.throws(hubController.translatePlatforms(config.hubId, authInfo, config.subscription.sampleFeed, verificationInfo)); 
    t.is(error.name, "OpenT2TError");
-   t.is(error.statusCode, 400);
-   t.is(error.innerError.message, "Payload signature doesn't match.");
+   t.is(error.statusCode, 401);
+   t.is(error.innerError.message, OpenT2TConstants.HMacSignatureVerificationFailed);
 });
 
 test.serial('InvalidHubIdThrowsForAnyAPI', async t => {
     const error = await t.throws(hubController.onboard("NonExistentHub", onboardingConfig.onboardingInfo));
     t.is(error.name, "OpenT2TError");
-    t.is(error.statusCode, 400);
-    t.is(error.innerError.message, "Invalid hub id");
+    t.is(error.statusCode, 404);
+    t.is(error.innerError.message, OpenT2TConstants.InvalidHubId);
 });
 
 test.serial('UndefinedOnboardingInfoForRefreshAuthTokenThrows', async t => {
     const error = await t.throws(hubController.refreshAuthToken(config.hubId, "undefined", authInfo));
     t.is(error.name, "OpenT2TError");
-    t.is(error.statusCode, 400);
-    t.is(error.innerError.message, "Invalid authInfo object.Please provide the existing authInfo object  with clientId + client_secret to allow the oAuth token to be refreshed");
+    t.is(error.statusCode, 401);
+    t.is(error.innerError.message, OpenT2TConstants.InvalidAuthInfoInput);
 });
 
 test.serial('InvalidOnboardingInfoForRefreshAuthTokenThrows', async t =>{
     var invalidOnboardingConfig = require('./hubController-testConfig-Invalidauth.json');
     const error = await t.throws(hubController.refreshAuthToken(config.hubId, invalidOnboardingConfig.onboardingInfo, authInfo));
     t.is(error.name, "OpenT2TError");
-    t.is(error.statusCode, 400);
-    t.is(error.innerError.message, "Invalid authInfo object.Please provide the existing authInfo object  with clientId + client_secret to allow the oAuth token to be refreshed");
+    t.is(error.statusCode, 401);
+    t.is(error.innerError.message, OpenT2TConstants.InvalidAuthInfoInput);
 });

--- a/node/tests/hubController.js
+++ b/node/tests/hubController.js
@@ -139,3 +139,25 @@ test.serial('translatePlatformsInvalidHmac', async t => {
    t.is(error.statusCode, 400);
    t.is(error.innerError.message, "Payload signature doesn't match.");
 });
+
+test.serial('InvalidHubIdThrowsForAnyAPI', async t => {
+    const error = await t.throws(hubController.onboard("NonExistentHub", onboardingConfig.onboardingInfo));
+    t.is(error.name, "OpenT2TError");
+    t.is(error.statusCode, 400);
+    t.is(error.innerError.message, "Invalid hub id");
+});
+
+test.serial('UndefinedOnboardingInfoForRefreshAuthTokenThrows', async t => {
+    const error = await t.throws(hubController.refreshAuthToken(config.hubId, "undefined", authInfo));
+    t.is(error.name, "OpenT2TError");
+    t.is(error.statusCode, 400);
+    t.is(error.innerError.message, "Invalid authInfo object.Please provide the existing authInfo object  with clientId + client_secret to allow the oAuth token to be refreshed");
+});
+
+test.serial('InvalidOnboardingInfoForRefreshAuthTokenThrows', async t =>{
+    var invalidOnboardingConfig = require('./hubController-testConfig-Invalidauth.json');
+    const error = await t.throws(hubController.refreshAuthToken(config.hubId, invalidOnboardingConfig.onboardingInfo, authInfo));
+    t.is(error.name, "OpenT2TError");
+    t.is(error.statusCode, 400);
+    t.is(error.innerError.message, "Invalid authInfo object.Please provide the existing authInfo object  with clientId + client_secret to allow the oAuth token to be refreshed");
+});

--- a/node/tests/hubController.js
+++ b/node/tests/hubController.js
@@ -137,4 +137,5 @@ test.serial('translatePlatformsInvalidHmac', async t => {
    const error = await t.throws(hubController.translatePlatforms(config.hubId, authInfo, config.subscription.sampleFeed, verificationInfo)); 
    t.is(error.name, "OpenT2TError");
    t.is(error.statusCode, 400);
+   t.is(error.innerError.message, "Payload signature doesn't match.");
 });


### PR DESCRIPTION
- Updated readme with respect to error handling while apiary still needs to be updated (TODO)
- Updated readme with respect to setting up for and running tests.
- Updated hubcontroller class to reject promises with new transformed error. 
- Updated existing InvalidHMacTests to expect specific error as part of the rejected promise.
- How validated - Using Wink Hub config and existing unit tests for hubController
- All existing 10 tests pass: 


----------------- translatePlatforms
----------------- _getHubInfo
----------------- _createTranslator opent2t-translator-com-wink-hub
 custom error message:           OpenT2T call failed in: translatePlatforms; Original message: Payload signature doesn't match.
 custom error name:           OpenT2TError
 custom error statusCode:           400
 custom error innerError message:           Payload signature doesn't match.
 custom error innerError stack:           OpenT2TError: Payload signature doesn't match.
    at OpenT2TError (c:\opent2t\lib\OpenT2TError.ts:10:9)
    at Translator.getPlatforms (c:\opent2t\opent2t\node\node_modules\opent2t-translator-com-wink-hub\org.opent2t.sample.hub.superpopular\com.wink.hub\js\thingTranslator.js:55:27)
    at Function.<anonymous> (c:\opent2t\lib\OpenT2T.ts:301:29)
    at next (native)
    at c:\opent2t\opent2t\node\OpenT2T.js:7:71
    at __awaiter (c:\opent2t\opent2t\node\OpenT2T.js:3:12)
    at Function.invokeMethodAsync (c:\opent2t\opent2t\node\OpenT2T.js:214:16)
    at _createTranslator.then (c:\opent2t\sj\cloud\node\hubController.js:257:37)
    at process._tickCallback (internal/process/next_tick.js:103:7)

   10 passed

- Manual tests to simulate various HttpRequest + non request-promise errors. TODO : add moer error scenarios for different APIs in the hubController tests.