### PR TITLE
Fixing test hmac generation

### DIFF
--- a/node/tests/hubController.js
+++ b/node/tests/hubController.js
@@ -109,7 +109,7 @@ test.serial('translatePlatforms', async t => {
 
     // Calculate an HMAC for the message that will be validated successfully
     var hmac = require('crypto').createHmac('sha1', config.subscriptionInfo.key);
-    hmac.update(config.subscription.sampleFeed.toString());
+    hmac.update(JSON.stringify(config.subscription.sampleFeed;
     verificationInfo.hmac = hmac.digest("hex");
     verificationInfo.header = {
         "X-Hub-Signature": verificationInfo.hmac

--- a/node/tests/hubController.js
+++ b/node/tests/hubController.js
@@ -109,7 +109,7 @@ test.serial('translatePlatforms', async t => {
 
     // Calculate an HMAC for the message that will be validated successfully
     var hmac = require('crypto').createHmac('sha1', config.subscriptionInfo.key);
-    hmac.update(JSON.stringify(config.subscription.sampleFeed;
+    hmac.update(JSON.stringify(config.subscription.sampleFeed));
     verificationInfo.hmac = hmac.digest("hex");
     verificationInfo.header = {
         "X-Hub-Signature": verificationInfo.hmac


### PR DESCRIPTION
Matching HMAC generation to the translators using JSON.stringify instead of toString()