### PR TITLE
"BUG:11368680 - Fixing HubController error handler to be more robust;

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opent2t-cloud",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Helper classes and interface to manage opent2t cloud components. For now only the hubController management class",
   "main": "hubController.js",
   "files": [

--- a/node/tests/hubController-testConfig.json
+++ b/node/tests/hubController-testConfig.json
@@ -4,14 +4,14 @@
         "opent2tBlob" : {
             "schema":"opent2t.p.light",
             "translator":"opent2t-translator-com-wink-lightbulb",
-            "controlId":"2167953"
+            "controlId":"2516533"
         }
     }, 
     "setResource": { 
         "opent2tBlob" : {
             "schema":"opent2t.p.light",
             "translator":"opent2t-translator-com-wink-lightbulb",
-            "controlId":"2167953"
+            "controlId":"2516533"
         },
         "deviceId": "F8CFB903-58BB-4753-97E0-72BD7DBC7933",
         "resource": "power",


### PR DESCRIPTION
 Also special-case handling rejected promises from lower levels that may not be rejected with an Error at all (Eg NEST hub translator rejects PutDeviceDetailsAsync with the error message and not error object itself which needs to be fixed also.
Had been working on hubcontroller tests to allow for translator mocks that will aid in invalid scenario testing like this using 'Mockery' but turns out that the code in hubController builds its own path to the translators using the localpackagesource logic, making it difficult to override the translator cache path during testing. It might be do-able but I didn't have enough time to spend on this at the moment, but meanwhile, Kurtis has pulled these changes into his (IFS') version of the hubcontroller class and verified it working.